### PR TITLE
Fixed bug with the highscore menu, caused by static variables not bei…

### DIFF
--- a/ADayAtStunlock/Assets/Scripts/Npc/MoneyManager.cs
+++ b/ADayAtStunlock/Assets/Scripts/Npc/MoneyManager.cs
@@ -12,6 +12,7 @@ public class MoneyManager : MonoBehaviour
     int npcIncome;
     int startMoney;
 
+    HighscoreListScreen highscoreListScreen;
     ScoreDisplay scoreDisplay;
 
     //Use this as a display while playing
@@ -31,6 +32,8 @@ public class MoneyManager : MonoBehaviour
 
 	void Start ()
     {
+
+        highscoreListScreen = HighscoreListScreen.thisInstance;
         moneyLost = 0;
         moneyEarned = 0;
         startMoney = 12500;
@@ -107,7 +110,7 @@ public class MoneyManager : MonoBehaviour
     void LoseGame()
     {
         DAS.TimeSystem.PauseTime();
-        HighscoreListScreen.DisplayHighscoreScreen();
-        HighscoreListScreen.DisplayScores();
+        highscoreListScreen.DisplayHighscoreScreen();
+        highscoreListScreen.DisplayScores();
     }
 }

--- a/ADayAtStunlock/Assets/Scripts/Random Events/EventDisplay.cs
+++ b/ADayAtStunlock/Assets/Scripts/Random Events/EventDisplay.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
+
 public class EventDisplay : MonoBehaviour
 {
     public bool showGUI = true;

--- a/ADayAtStunlock/Assets/Scripts/Score/HighscoreListScreen.cs
+++ b/ADayAtStunlock/Assets/Scripts/Score/HighscoreListScreen.cs
@@ -4,22 +4,28 @@ using UnityEngine;
 using UnityEngine.UI;
 
 public class HighscoreListScreen : MonoBehaviour {
+   
+    Text[] names;
+    
+    Text[] scores;
 
-    GameObject namesObject;
-    static Text[] names;
+    public static HighscoreListScreen thisInstance;
 
-    GameObject scoresObject;
-    static Text[] scores;
+    InputField inputField;
 
-    static GameObject thisInstance;
-
-    static InputField inputField;
-
-    static Text playerScoreText;
+    Text playerScoreText;
 
     private void Awake()
     {
-        thisInstance = gameObject;
+
+        if(thisInstance == null)
+        {
+            thisInstance = this;
+        }
+        else if(thisInstance != this)
+        {
+            Destroy(gameObject);
+        }
 
         names = gameObject.transform.Find("LeftPanel").transform.Find("Names").gameObject.GetComponentsInChildren<Text>(true);
 
@@ -29,13 +35,22 @@ public class HighscoreListScreen : MonoBehaviour {
         inputField.contentType = InputField.ContentType.Alphanumeric;
         inputField.onEndEdit.AddListener(delegate { SaveName(); });
 
-        playerScoreText = gameObject.transform.Find("RightPanel").transform.Find("PlayerScore").GetComponentInChildren<Text>();
+        playerScoreText = gameObject.transform.Find("RightPanel").transform.Find("PlayerScore").GetComponentInChildren<Text>(true);
 
-        
+        foreach (var item in names)
+        {
+            item.text = "";
+        }
+
+        foreach (var item in scores)
+        {
+            item.text = "";
+        }
+
     }
+    
 
-
-    static public void DisplayScores()
+    public void DisplayScores()
     {
         for (int i = 0; i < Highscore.scores.Count; i++)
         {
@@ -44,15 +59,15 @@ public class HighscoreListScreen : MonoBehaviour {
         }
     }
 
-    static public void DisplayHighscoreScreen()
+    public void DisplayHighscoreScreen()
     {
-        thisInstance.SetActive(true);
+        thisInstance.gameObject.SetActive(true);
         inputField.readOnly = false;
         inputField.text = "";
         playerScoreText.text = MoneyManager.moneyEarned.ToString("n0");
     }
 
-    static void SaveName()
+    void SaveName()
     {
         if(inputField.text.Length > 0)
         {


### PR DESCRIPTION
As far as i've tested, the bug is fixed. You can now reload and switch scenes without losing functionality in the highscore screen. Caused by static variables not being kept on scene switch