### PR TITLE
Now stops all non-music sound effects after you lose the game.

### DIFF
--- a/ADayAtStunlock/Assets/Scripts/Audio/AudioManager.cs
+++ b/ADayAtStunlock/Assets/Scripts/Audio/AudioManager.cs
@@ -98,6 +98,20 @@ public class AudioManager : MonoBehaviour {
         source.Play();
     }
 
+    public void StopAllSoundEffects()
+    {
+        foreach (var helper in listOfAudioHelpers)
+        {
+            foreach (var sound in helper.listOfAudioSourcesOnObject)
+            {
+                if(sound.clip.name != "Backbay Lounge")
+                {
+                    sound.Stop();
+                }
+            }
+        }
+    }
+
     public void StopSound(string name, GameObject self)
     {
         //Get the values of the requested sound effect

--- a/ADayAtStunlock/Assets/Scripts/Npc/MoneyManager.cs
+++ b/ADayAtStunlock/Assets/Scripts/Npc/MoneyManager.cs
@@ -215,8 +215,11 @@ public class MoneyManager : MonoBehaviour
     /// </summary>
     private void LoseGame()
     {
+
         if (m_highscoreListScreen != null)
         {
+
+            AudioManager.instance.StopAllSoundEffects();
             DAS.TimeSystem.PauseTime();
             m_highscoreListScreen.DisplayHighscoreScreen();
             //highscoreListScreen.DisplayScores();


### PR DESCRIPTION
Made sure the game stops all annoying sound effects when the game ends and shows you the highscore screen. No more radiators banging in the background after losing the game.